### PR TITLE
Register NIST phantom data to ROI for subsequent quantification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,5 @@ Run the registration script:
 python register_t1maps_nist.py -j configs/3T_NIST.json -p 3T_NIST_pooled/ 3T_NIST_T1maps_pooled/
 ```
 
-Note: you can specify which reference image (aka target) to choose for co-registering all the sites by editing the 
-`configs/.json` file and adding the field `"reference": true`. Example:
-
-```xml
-    "guillaumegilbert_muhc_NIST":{
-        "OSF_link": "https://osf.io/qnhjt/download/",
-        "datasets":{
-            "magnitude": {
-                "dataType": "Magnitude",
-                "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Magnitude.nii.gz",
-                "reference": true
-            },
-```
+Note: the registration script will download the reference mask (e.g. for the NIST phantom)
+and will create labels for the initial affine transformation. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Prerequesites
 
-* [ANTs](https://github.com/ANTsX/ANTs)
+* [ANTs](https://github.com/ANTsX/ANTs) (tested with version 2.3.3.dev168-g29bdf)
 * Python 3.7
 * Clone this repository and install its requirements:
   ````bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 ### Prerequesites
 
 * [ANTs](https://github.com/ANTsX/ANTs)
-* [FSL](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/)
 * Python 3.7
 * Clone this repository and install its requirements:
   ````bash

--- a/configs/3T_NIST.json
+++ b/configs/3T_NIST.json
@@ -69,7 +69,7 @@
         "datasets":{
             "magnitude": {
                 "dataType": "Magnitude",
-                "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Magnitude.nii.gz",
+                "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Magnitude.nii.gz"
             },
             "complex": {
                 "dataType": "Complex",

--- a/configs/3T_NIST.json
+++ b/configs/3T_NIST.json
@@ -70,7 +70,6 @@
             "magnitude": {
                 "dataType": "Magnitude",
                 "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Magnitude.nii.gz",
-                "reference": true
             },
             "complex": {
                 "dataType": "Complex",

--- a/configs/3T_NIST_T1maps.json
+++ b/configs/3T_NIST_T1maps.json
@@ -205,14 +205,6 @@
     "ngmaforo_ucla_NIST":{
         "OSF_link": "https://osf.io/ab2zg/download/",
         "datasets":{
-            "Prisma_noFS": {
-                "dataType": "Magnitude",
-                "imagePath": "20200305_ngmaforo_ucla_NIST/20200305_ngmaforo_ucla_Prisma_noFS_NIST_Magnitude_T1map.nii.gz"
-            },
-            "Prisma_FS": {
-                "dataType": "Magnitude",
-                "imagePath": "20200305_ngmaforo_ucla_NIST/20200305_ngmaforo_ucla_Prisma_FS_NIST_Magnitude_T1map.nii.gz"
-            },
             "Skyra_noFS": {
                 "dataType": "Magnitude",
                 "imagePath": "20200305_ngmaforo_ucla_NIST/20200305_ngmaforo_ucla_Skyra_noFS_NIST_Magnitude_T1map.nii.gz"

--- a/configs/3T_NIST_T1maps_rois.json
+++ b/configs/3T_NIST_T1maps_rois.json
@@ -1,0 +1,236 @@
+{
+    "matthewgrechsollars_ICL_NIST":{
+        "OSF_link": "https://osf.io/e7av8/download/",
+        "datasets":{
+            "magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200121_matthewgrechsollars_ICL_NIST/20200121_matthewgrechsollars_ICL_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "complex": {
+                "dataType": "Complex",
+                "imagePath": "20200121_matthewgrechsollars_ICL_NIST/20200121_matthewgrechsollars_ICL_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "siyuanhu_casewestern_NIST":{
+        "OSF_link": "https://osf.io/ms53d/download/",
+        "datasets":{
+            "one": {
+                "dataType": "Magnitude",
+                "imagePath": "20200124_siyuanhu_casewestern_NIST/20200124_siyuanhu_casewestern_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "iveslevesque_muhc_mgh_NIST":{
+        "OSF_link": "https://osf.io/yx6tq/download/",
+        "datasets":{
+            "one": {
+                "dataType": "Magnitude",
+                "imagePath": "20200203_iveslevesque_muhc_mgh_NIST/20200203_iveslevesque_muhc_mgh_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "mrel_usc_NIST":{
+        "OSF_link": "https://osf.io/dhyp5/download/",
+        "datasets":{
+            "Session1_MR1": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200204_mrel_usc_GE3T_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Session1_MR2": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200204_mrel_usc_GE3T_MR2_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Session2_MR1": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200209_mrel_usc_GE3T_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Session2_MR1_TR10sec": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200209_mrel_usc_GE3T_MR1_TR10sec_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Session2_MR2": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200209_mrel_usc_GE3T_MR2_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Session2_MR2_TR10sec": {
+                "dataType": "Magnitude",
+                "imagePath": "20200204_mrel_usc_NIST/20200209_mrel_usc_GE3T_MR2_TR10sec_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "guillaumegilbert_muhc_NIST":{
+        "OSF_link": "https://osf.io/pd9by/download/",
+        "datasets":{
+            "magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "complex": {
+                "dataType": "Complex",
+                "imagePath": "20200210_guillaumegilbert_muhc_NIST/20200210_guillaumegilbert_muhc_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "CStehningPhilipsClinicalScienceGermany_NIST":{
+        "OSF_link": "https://osf.io/9psu6/download/",
+        "datasets":{
+            "Aachen_MR1_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Aachen_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Aachen_MR1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Aachen_MR1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Berlin_MR1_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Berlin_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Berlin_MR1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Berlin_MR1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Bonn_MR1_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Bonn_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Bonn_MR1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Bonn_MR1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR1_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR3_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR3_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR3_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR3_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR4_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR4_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Cologne_MR4_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Cologne_MR4_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "Hamburg_MR1_magnitude": {
+                "dataType": "Magnitude",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Hamburg_MR1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Hamburg_MR1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200225_CStehningPhilipsClinicalScienceGermany_NIST/20200225_CStehningPhilipsClinicalScienceGermany_Hamburg_MR1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "iveslevesque_muhc_glen_NIST":{
+        "OSF_link": "https://osf.io/eq364/download/",
+        "datasets":{
+            "PowerError": {
+                "dataType": "Magnitude",
+                "imagePath": "20200226_iveslevesque_muhc_glen_NIST/PowerError/20200226_iveslevesque_muhc_glen_PowerError_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "NoPowerError": {
+                "dataType": "Magnitude",
+                "imagePath": "20200226_iveslevesque_muhc_glen_NIST/NoPowerError/20200226_iveslevesque_muhc_glen_NoPowerError_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "karakuzu_polymtl_NIST":{
+        "OSF_link": "https://osf.io/f7mby/download/",
+        "datasets":{
+            "unf": {
+                "dataType": "Magnitude",
+                "imagePath": "20200227_karakuzu_polymtl_NIST/20191213_UNF/20191213_karakuzu_UNF_FS_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "mni": {
+                "dataType": "Magnitude",
+                "imagePath": "20200227_karakuzu_polymtl_NIST/20200227_MNI/20200227_karakuzu_mni_FS_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "madelinecarr_lha_NIST":{
+        "OSF_link": "https://osf.io/f96vm/download/",
+        "datasets":{
+            "one": {
+                "dataType": "Magnitude",
+                "imagePath": "20200227_madelinecarr_lha_NIST/20200227_madelinecarr_lha_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "niloufar_hfmc_NIST":{
+        "OSF_link": "https://osf.io/zevm6/download/",
+        "datasets":{
+            "4point": {
+                "dataType": "Magnitude",
+                "imagePath": "20200229_niloufar_hfmc_NIST/20200229_niloufar_hfmc_4point_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "14point": {
+                "dataType": "Magnitude",
+                "imagePath": "20200229_niloufar_hfmc_NIST/20200229_niloufar_hfmc_14point_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "wang_MDAnderson_NIST":{
+        "OSF_link": "https://osf.io/53dca/download/",
+        "datasets":{
+            "day1_mag": {
+                "dataType": "Magnitude",
+                "imagePath": "20200302_wang_MDAnderson_NIST/day1/20200302_wang_MDAnderson_day1_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "day1_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200302_wang_MDAnderson_NIST/day1/20200302_wang_MDAnderson_day1_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            },
+            "day2_mag": {
+                "dataType": "Magnitude",
+                "imagePath": "20200302_wang_MDAnderson_NIST/day2/20200302_wang_MDAnderson_day2_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "day2_complex": {
+                "dataType": "Complex",
+                "imagePath": "20200302_wang_MDAnderson_NIST/day2/20200302_wang_MDAnderson_day2_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "ngmaforo_ucla_NIST":{
+        "OSF_link": "https://osf.io/zrc89/download/",
+        "datasets":{
+            "Skyra_noFS": {
+                "dataType": "Magnitude",
+                "imagePath": "20200305_ngmaforo_ucla_NIST/20200305_ngmaforo_ucla_Skyra_noFS_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            },
+            "Skyra_FS": {
+                "dataType": "Magnitude",
+                "imagePath": "20200305_ngmaforo_ucla_NIST/20200305_ngmaforo_ucla_Skyra_FS_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "near_douglas_NIST":{
+        "OSF_link": "https://osf.io/tfd9b/download/",
+        "datasets":{
+            "one": {
+                "dataType": "Magnitude",
+                "imagePath": "20200309_near_douglas_NIST/20200309_near_douglas_NIST_Magnitude_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    },
+    "jalnefjord_sahlgrenska_NIST":{
+        "OSF_link": "https://osf.io/gbjta/download/",
+        "datasets":{
+            "one": {
+                "dataType": "Complex",
+                "imagePath": "20201802_jalnefjord_sahlgrenska_NIST/20201802_jalnefjord_sahlgrenska_NIST_Complex_T1map_modifheader_mask.nii.gz"
+            }
+        }
+    }
+}

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -69,7 +69,8 @@ def copy_header(fname_src, fname_ref):
     """
     nii_src = nibabel.load(fname_src)
     nii_ref = nibabel.load(fname_ref)
-    nii_src_in_ref = nibabel.Nifti1Image(nii_src.get_fdata(), nii_ref.affine, nii_src.header)
+    # Squeeze is needed to enforce 2d image
+    nii_src_in_ref = nibabel.Nifti1Image(np.squeeze(nii_src.get_fdata()), nii_ref.affine, nii_src.header)
     fname_out = add_suffix(fname_src, SUFFIXMODIFHEADER)
     nibabel.save(nii_src_in_ref, fname_out)
     return fname_out
@@ -232,8 +233,8 @@ def main():
                     list_jpg.append(convert_nifti_to_jpeg(fname_mag_src_reg, file_mag))
                     # Apply inverse transformation to ref_mask
                     # Here: assuming that T1maps have the same prefix as the file under 3T_NIST
-                    # fname_t1map = copy_header(Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP)), fname_ref)
-                    fname_t1map = Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP))
+                    fname_t1map = copy_header(Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP)), fname_ref)
+                    # fname_t1map = Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP))
                     # Apply inverse transformation of masks to t1map native space
                     run_subprocess('antsApplyTransforms -d 2 -r {} -i {} -o {} -t [{},1] -v'.format(
                         fname_label, Path(path_roi, FILEROIFINAL), add_suffix(fname_t1map, '_mask'), fname_affine))

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -216,7 +216,7 @@ def main():
                 else:
                     print("Label does not exist. Skipping this image.")
     # Also convert the reference image
-    run_subprocess('ConvertToJpg {} {}'.format(fname_ref, fname_ref.replace('nii.gz', 'jpg')))
+    run_subprocess('ConvertToJpg {} {}'.format(fname_ref, fname_ref.as_posix().rstrip('.nii.gz').rstrip('.nii')+'.jpg'))
     # Create gif
     file_gif = 'results_reg_{}.gif'.format(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
     creategif(glob.glob(os.path.join(input_folders[0], '*echo*_reg.jpg')), file_gif, duration=0.3)

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -4,14 +4,12 @@ import os
 import sys
 import json
 from pathlib import Path
-import shutil
 import subprocess
 import argparse
-import glob
 import datetime
 import nibabel
 import numpy as np
-from PIL import Image, ImageFont, ImageDraw
+from PIL import Image, ImageDraw
 import wget
 import zipfile
 

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -167,19 +167,12 @@ def main():
                 # the ref image), causing the label-based transformation to fail. For this
                 # reason, we need to copy header information from the ref image to the
                 # moving image.
-                # Note: I've also tried flipping the image and labels using PermuteFlipImageOrientationAxes
-                # but for some reasons i do not understand, the flipping does not produce
-                # the same qform between the output image and labels (even though the inputs
-                # have the same qform...).
-
+                # TODO: create a function for header copy
                 nii_src = nibabel.load(fname_mag_echo)
                 nii_ref = nibabel.load(fname_ref)
                 nii_src_in_ref = nibabel.Nifti1Image(nii_src.get_fdata(), nii_ref.affine, nii_src.header)
                 fname_mag_src = add_suffix(fname_mag_echo, SUFFIXMODIFHEADER)
                 nibabel.save(nii_src_in_ref, fname_mag_src)
-
-                # shutil.copy(fname_mag_echo, fname_mag_src)
-                # run_subprocess('fslcpgeom {} {} -d'.format(fname_ref, fname_mag_src))
                 # bring label to proper folder and update header
                 # Here: assuming that T1maps have the same prefix as the file under 3T_NIST
                 fname_label_src = Path(input_folders[1], add_suffix(file_mag, SUFFIXLABEL))
@@ -188,10 +181,6 @@ def main():
                     nii_src = nibabel.load(fname_label_src)
                     nii_src_in_ref = nibabel.Nifti1Image(nii_src.get_fdata(), nii_ref.affine, nii_src.header)
                     nibabel.save(nii_src_in_ref, fname_label)
-
-                    # shutil.copy(fname_label_src, fname_label)
-                    # run_subprocess('fslcpgeom {} {} -d'.format(fname_ref, fname_label))
-
                     # Label-based registration
                     fname_affine = Path(input_folders[0], str(file_mag).replace('Magnitude.nii.gz', 'Magnitude_affine-label.mat'))
                     run_subprocess('antsLandmarkBasedTransformInitializer 2 {} {} affine {}'.format(

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -236,7 +236,7 @@ def main():
                     fname_t1map = copy_header(Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP)), fname_ref)
                     # fname_t1map = Path(input_folders[1], add_suffix(file_mag, SUFFIXT1MAP))
                     # Apply inverse transformation of masks to t1map native space
-                    run_subprocess('antsApplyTransforms -d 2 -r {} -i {} -o {} -t [{},1] -v'.format(
+                    run_subprocess('antsApplyTransforms -d 2 -n NearestNeighbor -r {} -i {} -o {} -t [{},1] -v'.format(
                         fname_label, Path(path_roi, FILEROIFINAL), add_suffix(fname_t1map, '_mask'), fname_affine))
                 else:
                     print("Label does not exist. Skipping this image.")

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -10,6 +10,8 @@ import argparse
 import glob
 import datetime
 from PIL import Image, ImageFont, ImageDraw
+import wget
+import zipfile
 
 from gifmaker.gifmaker import creategif
 
@@ -53,6 +55,22 @@ def add_suffix(fname, suffix):
 
     stem, ext = _splitext(fname)
     return os.path.join(stem + suffix + ext)
+
+
+def download_roi(url='https://osf.io/abfmg/download', folder_out='roi'):
+    """
+    Download ROIs from the internet and extract archive.
+    :param url:
+    :param folder_out:
+    :return: output folder of extracted ROIs
+    """
+    # TODO: do this download outside of this CLI (ie should be part of another "install required data" CLI)
+    print("\nDownloading ROIs...")
+    fname_roi = wget.download(url)
+    with zipfile.ZipFile(fname_roi, 'r') as zip_ref:
+        zip_ref.extractall(folder_out)
+    os.remove(fname_roi)
+    return os.path.abspath(folder_out)
 
 
 def run_subprocess(cmd):
@@ -100,6 +118,9 @@ def main():
     # Load config file for datasets
     with open(config_files[0]) as json_file:
         config_json = json.load(json_file)
+
+    # Download ROIs
+    path_roi = download_roi()
 
     # Get reference image
     fname_mag_ref = Path(input_folders[0], '20200210_guillaumegilbert_muhc_NIST_Magnitude.nii.gz')

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -216,10 +216,11 @@ def main():
                 else:
                     print("Label does not exist. Skipping this image.")
     # Also convert the reference image
-    run_subprocess('ConvertToJpg {} {}'.format(fname_ref, fname_ref.as_posix().rstrip('.nii.gz').rstrip('.nii')+'.jpg'))
+    fname_ref_jpg = fname_ref.as_posix().rstrip('.nii.gz').rstrip('.nii')+'.jpg'
+    run_subprocess('ConvertToJpg {} {}'.format(fname_ref, fname_ref_jpg))
     # Create gif
     file_gif = 'results_reg_{}.gif'.format(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
-    creategif(glob.glob(os.path.join(input_folders[0], '*echo*_reg.jpg')), file_gif, duration=0.3)
+    creategif([fname_ref_jpg]+glob.glob(os.path.join(input_folders[0], '*echo*_reg.jpg')), file_gif, duration=0.3)
     print("\nFinished! \n--> {}".format(file_gif))
 
 

--- a/register_t1maps_nist.py
+++ b/register_t1maps_nist.py
@@ -130,11 +130,14 @@ def main():
     # Create labels on ref image and save as nifti file
     data_ref_label = np.zeros_like(nii_ref.get_fdata())
     # TODO: move the hard-coded part below somewhere else
-    coord_labels = [(95, 154), (39, 77), (151, 77)]
-    for coord_label in coord_labels:
+    coord_labels = {
+        1: (95, 154),
+        2: (39, 77),
+        3: (151, 77)}
+    for value, coord in coord_labels.items():
         # Here, instead of creating single-point label, we create 3x3 labels. More details here:
         #  https://github.com/rrsg2020/analysis/issues/1#issuecomment-664495177
-        data_ref_label[coord_label[0]-1: coord_label[0]+2, coord_label[1]-1: coord_label[1]+2] = 1
+        data_ref_label[coord[0]-1: coord[0]+2, coord[1]-1: coord[1]+2] = value
     nii_label_ref = nibabel.Nifti1Image(data_ref_label, nii_ref.affine, nii_ref.header.copy())
     fname_label_ref = add_suffix(fname_ref, '_labels')
     nibabel.save(nii_label_ref, fname_label_ref)


### PR DESCRIPTION
Extending on #6, the purpose of this PR is to set up a pipeline to register the NIST phantom data to the ROI for subsequent mask-based quantification. 

The following has been done:
- [x] Download ROIs when running `register_t1maps_nist.py`
- [x] Create initial labels for registering the ROI to all NIST phantom data
- [x] Update the registration parameters to work with synthetic phantom instead of with an arbitrary reference site (previously: gilbert)
- [x] Apply the inverse transformation of each site to the curated ROI (labeled, eroded).

Additional improvements:
- Removed FSL dependency (now using nibabel)

Fixes #1 